### PR TITLE
Add support for non-comparable types

### DIFF
--- a/st.go
+++ b/st.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"reflect"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 // Expect calls t.Error and prints a nice comparison message when act != exp.
 // Especially useful in table-based tests when passing the loop index as iter.
 func Expect(t testing.TB, act interface{}, exp interface{}, iter ...int) {
-	if act != exp {
+	if !reflect.DeepEqual(act, exp) {
 		file, line := caller()
 		t.Errorf(equal, file, line, exampleNum(iter), exp, exp, act, act)
 	}
@@ -35,7 +36,7 @@ func Expect(t testing.TB, act interface{}, exp interface{}, iter ...int) {
 // Reject calls t.Error and prints a nice comparison message when act == exp.
 // Especially useful in table-based tests when passing the loop index as iter.
 func Reject(t testing.TB, act interface{}, exp interface{}, iter ...int) {
-	if act == exp {
+	if reflect.DeepEqual(act, exp) {
 		file, line := caller()
 		t.Errorf(unequal, file, line, exampleNum(iter), exp, exp, act, act)
 	}
@@ -44,7 +45,7 @@ func Reject(t testing.TB, act interface{}, exp interface{}, iter ...int) {
 // Assert calls t.Fatal to abort the test immediately and prints a nice
 // comparison message when act != exp.
 func Assert(t testing.TB, act interface{}, exp interface{}) {
-	if act != exp {
+	if !reflect.DeepEqual(act, exp) {
 		file, line := caller()
 		t.Fatalf(equal, file, line, "", exp, exp, act, act)
 	}
@@ -53,7 +54,7 @@ func Assert(t testing.TB, act interface{}, exp interface{}) {
 // Refute calls t.Fatal to abort the test immediately and prints a nice
 // comparison message when act != exp.
 func Refute(t testing.TB, act interface{}, exp interface{}) {
-	if act == exp {
+	if reflect.DeepEqual(act, exp) {
 		file, line := caller()
 		t.Fatalf(unequal, file, line, "", exp, exp, act, act)
 	}

--- a/st_test.go
+++ b/st_test.go
@@ -26,12 +26,14 @@ func TestExpectReject(t *testing.T) {
 	Expect(t, 42, 42)
 	Expect(t, nil, nil)
 	Expect(t, stTestInterface(nil), nil)
+	Expect(t, []int{42}, []int{42})
 
 	// Standard rejections
 	Reject(t, "a", "A")
 	Reject(t, 42, int64(42.0))
 	Reject(t, 42, 42.0)
 	Reject(t, 42, "42")
+	Reject(t, []int{42}, []int{41})
 	Reject(t, stTest{}, nil)
 	Reject(t, []string{}, nil)
 	Reject(t, []stTest{}, nil)
@@ -62,12 +64,14 @@ func TestAssertRefute(t *testing.T) {
 	Assert(t, "a", "a")
 	Assert(t, 42, 42)
 	Assert(t, nil, nil)
+	Assert(t, []int{42}, []int{42})
 
 	// Standard refutations
 	Refute(t, "a", "A")
 	Refute(t, 42, int64(42.0))
 	Refute(t, 42, 42.0)
 	Refute(t, 42, "42")
+	Refute(t, []int{42}, []int{41})
 	Refute(t, []string{}, nil)
 	Refute(t, []stTest{}, nil)
 


### PR DESCRIPTION
This pull request adds support for non-comparable types, such as maps and slices, using the [reflect.DeepEqual](http://golang.org/pkg/reflect/#DeepEqual) function. This in turn "uses normal == equality where possible" so this shouldn't cause any problems.
