### PR TITLE
Add iteration to Assert and Refute

### DIFF
--- a/st.go
+++ b/st.go
@@ -53,19 +53,19 @@ func Reject(t Errorf, have, want interface{}, iter ...int) {
 
 // Assert calls t.Fatal to abort the test immediately and prints a nice
 // comparison message when have != want.
-func Assert(t Fatalf, have, want interface{}) {
+func Assert(t Fatalf, have, want interface{}, iter ...int) {
 	if !reflect.DeepEqual(have, want) {
 		file, line := caller()
-		t.Fatalf(equal, file, line, "", have, have, want, want)
+		t.Fatalf(equal, file, line, exampleNum(iter), have, have, want, want)
 	}
 }
 
 // Refute calls t.Fatal to abort the test immediately and prints a nice
 // comparison message when have != want.
-func Refute(t Fatalf, have, want interface{}) {
+func Refute(t Fatalf, have, want interface{}, iter ...int) {
 	if reflect.DeepEqual(have, want) {
 		file, line := caller()
-		t.Fatalf(unequal, file, line, "", have, have, want, want)
+		t.Fatalf(unequal, file, line, exampleNum(iter), have, have, want, want)
 	}
 }
 

--- a/st_test.go
+++ b/st_test.go
@@ -5,6 +5,7 @@ package st
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 )
 
@@ -103,4 +104,20 @@ func Test_exampleNum(t *testing.T) {
 	Expect(t, exampleNum(expectationFunc(t, 0)), "0.")
 	Expect(t, exampleNum(expectationFunc(t, 1)), "1.")
 	Expect(t, exampleNum(expectationFunc(t, 2)), "2.")
+}
+
+func ExampleAssert_usingIterator() {
+	t := new(testing.T)
+
+	examples := []string{
+		"http://localhost:3000/foo",
+		"http://localhost:3000/bar",
+	}
+
+	for i, example := range examples {
+		res, err := http.Get(example)
+
+		Assert(t, err, nil, i)
+		Expect(t, res.StatusCode, http.StatusUnauthorized, i)
+	}
 }


### PR DESCRIPTION
This standardizes the API for these functions. I've found myself needing to do some Assert/Refute calls within a table-based test where I need to Assert that some error condition isn't met.

Being able to see which element of the table caused the fatal error would be incredibly useful for me (and maybe others too!).
